### PR TITLE
Nodestalker cannot "put" unicode data into beanstalkd

### DIFF
--- a/lib/beanstalk_client.js
+++ b/lib/beanstalk_client.js
@@ -256,8 +256,14 @@ BeanstalkClient.prototype.put = function(data, priority, delay, ttr) {
 		ttr = 100000;
 	}
 	
+	function lengthInUtf8Bytes(str) {
+	  // Matches only the 10.. bytes that are non-initial characters in a multi-byte sequence.
+	  var m = encodeURIComponent(str).match(/%[89ABab]/g);
+	  return str.length + (m ? m.length : 0);
+	}
+
 	return this.command({
-		command: 'put '+priority+' '+delay+' '+ttr+' '+data.toString().length+'\r\n'+data+'\r\n',
+		command: 'put '+priority+' '+delay+' '+ttr+' '+lengthInUtf8Bytes(data.toString())+'\r\n'+data+'\r\n',
 		expected: 'INSERTED'
 	});
 };


### PR DESCRIPTION
Fixed this by putting a function to calculate unicode string length in bytes into the put function.
