### PR TITLE
stats-tube can return NOT_FOUND according to the protocol spec

### DIFF
--- a/lib/beanstalk_client.js
+++ b/lib/beanstalk_client.js
@@ -466,7 +466,7 @@ BeanstalkClient.prototype.statsJob = BeanstalkClient.prototype.stats_job;
 BeanstalkClient.prototype.stats_tube = function(tube) {
 	return this.command({
 		command: 'stats-tube '+tube+'\r\n',
-		expected: 'OK',
+		expected: ['OK', 'NOT_FOUND'],
 		is_yaml: 1
 	});
 };


### PR DESCRIPTION
Reference: https://github.com/kr/beanstalkd/blob/master/doc/protocol.txt

PS: thanks for the great library.
