### PR TITLE
Fixes calling consecutive commands when one has failed or timed out

### DIFF
--- a/lib/beanstalk_client.js
+++ b/lib/beanstalk_client.js
@@ -223,6 +223,7 @@ BeanstalkClient.prototype.command = function(obj) {
 
 	// if the command fails, event an error
 	cmd.addListener('command_error', function(data) {
+		_self.waitingForResponse = false;
 		_self.emit('end', 'Command failed');
 	});
 


### PR DESCRIPTION
Without this fix, calling reserve() or reserve_with_timeout(secs) can only be called once per open connection. This allows reserve to be called immediately after the previous reserve() call times out, which is more efficient then disconnecting and reconnecting to the beanstalkd server every time.
