### PR TITLE
Nodestalker hangs when reserving jobs with wide UTF characters

### DIFF
--- a/lib/beanstalk_client.js
+++ b/lib/beanstalk_client.js
@@ -142,7 +142,7 @@ BeanstalkCommand.prototype.responseHandler = function(data, callback) {
 	if(matches) {
 		var expectedLength = Number(matches[1]); 
 
-		if(matches[2].length < (expectedLength + 2)) {
+		if(Buffer.byteLength(matches[2], 'utf8') < (expectedLength + 2)) {
 			Debug.log( 'responseHandler waiting for more' );
 			this.multiBuffer = dataString;
 			

--- a/package.json
+++ b/package.json
@@ -2,13 +2,13 @@
     "name": "nodestalker"
     , "description": "A Beanstalk client for node.js"
     , "keywords": ["beanstalkd", "queue"]
-    , "version": "0.1.14"
+    , "version": "0.1.15"
     , "author": "Pascal Opitz <contact@pascalopitz.com> (http://blog.pascalopitz.com)"
     , "contributors" : [
         {
             "name" : "Andrew Houghton",
             "github" : "https://github.com/aahoughton"
-            },
+        },
         {
             "name" : "Amjad Mohamed",
             "github" : "https://github.com/andho"
@@ -32,6 +32,10 @@
         {
             "name" : "Brad Dwyer",
             "github" : "https://github.com/yeldarby"
+        },
+        {
+            "name" : "Joel Bradshaw",
+            "github" : "https://github.com/cincodenada"
         }
     ]
     , "repository": {

--- a/tests/helper.js
+++ b/tests/helper.js
@@ -39,5 +39,8 @@ module.exports = {
 	},
 	getClient : function () {
 		return bs.Client('127.0.0.1:' + port);
+	},
+	activateDebug : function() {
+		bs.Debug.activate();
 	}
 }

--- a/tests/test_utf8_reserve.js
+++ b/tests/test_utf8_reserve.js
@@ -1,0 +1,41 @@
+console.log('testing reserving jobs with utf8 data');
+
+var assert = require('assert');
+var helper = require('./helper');
+
+// Contains a 2-byte (ı) and 3-byte (n̈) UTF character
+// for a total of 13 bytes in 10 characters
+var utfstr = "Spın̈al Tap";
+
+helper.bind(function(conn, data) {
+	if(String(data) == "reserve\r\n") {
+		conn.write(
+			"RESERVED 1234 " + Buffer.byteLength(utfstr, 'utf8') + "\r\n" +
+			utfstr + "\r\n"
+		);
+	}
+}, true);
+var client = helper.getClient();
+
+var success = false;
+var error = false;
+
+client.reserve().onSuccess(function(job) {
+	assert.equal(job.data,utfstr)
+	success = true;
+	client.disconnect();
+}).onError(function(job) {
+	success = false;
+	client.disconnect();
+});
+
+client.addListener('error', function() {
+	error = true;
+});
+
+process.addListener('exit', function() {
+	assert.ok(!error);
+	assert.ok(success);
+	console.log('test passed');
+});
+


### PR DESCRIPTION
Similar to #12 (and in fact, I just adapted the fix from there), but a little different.  When the job body has UTF characters that are larger than 1 byte, the declared data length will be larger than the Javascript string length, which makes reserve() think there is additional multichunk data yet to come in, and it waits and eventually times out for the nonexistent further data, failing the job.

This fix just uses the same UTF-8 length check on the body, so that it matches with the declared length.

I've included a new test to verify the fix, I based it on the existing `test_reserve` and `test_utf8` tests, so it should work with Travis and things.