### PR TITLE
Adding compatibility with Buffers

### DIFF
--- a/lib/beanstalk_client.js
+++ b/lib/beanstalk_client.js
@@ -44,8 +44,9 @@ BeanstalkJob.create = function(data) {
 
 
 // ##Internal command object
-function BeanstalkCommand(obj) {
+function BeanstalkCommand(obj, isRaw) {
 	this._obj = obj;
+	this._isRaw = isRaw
 	events.EventEmitter.call(this);
 };
 util.inherits(BeanstalkCommand, events.EventEmitter);
@@ -156,8 +157,10 @@ BeanstalkCommand.prototype.responseHandler = function(data, callback) {
 			Debug.log( 'responseHandler waiting for more' );
 			this.multiBuffer = dataString;
 
-			// Store the buffer
-			this.rawBuffers.push(data);
+			if(this._isRaw) {
+				// Store the buffer because <data> is not completed yet
+				this.rawBuffers.push(data);
+			}
 			
 			this.multiErrorTimer = setTimeout(function () {
 				self.emit('command_error', chunks);
@@ -187,14 +190,20 @@ BeanstalkCommand.prototype.responseHandler = function(data, callback) {
 			chunks.shift();
 
 			if(jobdata) {
-				// Accumulate last chunk, deep copy of this.rawBuffers (prototype),
-				// and concatenate all buffers
-				this.rawBuffers.push(data);
-				var rawBuffersCopy = this.rawBuffers.slice();
-				var reserveOutput = Buffer.concat(rawBuffersCopy);
-
 				chunks.pop();
-				chunks.push(this.extractDataReserveOutput(reserveOutput));
+
+				if(this._isRaw) {
+					// Append last buffer, full copy of the array (prototype),
+					// create the full buffer and extract <data>
+					this.rawBuffers.push(data);
+					var rawBuffersCopy = this.rawBuffers.slice();
+					this.rawBuffers.length = 0;
+					var reserveOutput = Buffer.concat(rawBuffersCopy);
+					chunks.push(this._extractDataReserveOutput(reserveOutput));
+				} else {
+					chunks.push(jobdata);
+				}
+				
 				chunks = BeanstalkJob.create(chunks);
 			}
 		}
@@ -210,7 +219,7 @@ BeanstalkCommand.prototype.responseHandler = function(data, callback) {
  * Extract <data> from the full response for reserve command looking for
  * the first "\r\n" aparition.
  */
-BeanstalkCommand.prototype.extractDataReserveOutput = function(buff) {
+BeanstalkCommand.prototype._extractDataReserveOutput = function(buff) {
 	var i;
 	var length = buff.length;
 
@@ -229,6 +238,7 @@ function BeanstalkClient() {
 
 	this.address = '127.0.0.1';
 	this.port = 11300;
+	this.isRaw = false;
 	this.conn;
 	this.default_priority = 10;
 	this.reserve_multichunk_timeout = 500;
@@ -239,15 +249,17 @@ function BeanstalkClient() {
 util.inherits(BeanstalkClient, events.EventEmitter);
 
 // Singleton like method that returns an instance
-BeanstalkClient.prototype.Instance = function(config) {
+BeanstalkClient.prototype.Instance = function(config, isRaw) {
 	if (config) {
 		if (typeof config == 'string') {
 			var c = config.split(':');
 			this.address = c[0] || this.address;
 			this.port = c[1] || this.port;
+			this.isRaw = isRaw || this.isRaw;
 		} else {
 			this.address = config.address || this.address;
 			this.port = config.port || this.port;
+			this.isRaw = config.isRaw || this.isRaw;
 		}
 	}
 
@@ -258,7 +270,7 @@ BeanstalkClient.prototype.Instance = function(config) {
 BeanstalkClient.prototype.command = function(obj) {
 	var _self = this;
 	obj.reserve_multichunk_timeout = this.reserve_multichunk_timeout;
-	var cmd = new BeanstalkCommand(obj);
+	var cmd = new BeanstalkCommand(obj, this.isRaw);
 
 	// pushes commands to the server
 	var requestExec = function() {
@@ -629,9 +641,9 @@ BeanstalkClient.prototype._createPutCommand = function(data, priority, delay, tt
 };
 
 // ##Exposed to node
-var Beanstalk = function(server) {
+var Beanstalk = function(server, isRaw) {
 	var c = new BeanstalkClient;
-	return c.Instance(server);
+	return c.Instance(server, isRaw);
 };
 
 exports.Client = Beanstalk;

--- a/lib/beanstalk_client.js
+++ b/lib/beanstalk_client.js
@@ -112,6 +112,7 @@ BeanstalkCommand.prototype.onSuccess = function(fn) {
 };
 
 BeanstalkCommand.prototype.multiBuffer = null;
+BeanstalkCommand.prototype.rawBuffers = [];
 BeanstalkCommand.prototype.multiErrorTimer = null;
 BeanstalkCommand.prototype.multiErrorOccurred = false;
 
@@ -154,6 +155,9 @@ BeanstalkCommand.prototype.responseHandler = function(data, callback) {
 		if(Buffer.byteLength(matches[2], 'utf8') < (expectedLength + 2)) {
 			Debug.log( 'responseHandler waiting for more' );
 			this.multiBuffer = dataString;
+
+			// Store the buffer
+			this.rawBuffers.push(data);
 			
 			this.multiErrorTimer = setTimeout(function () {
 				self.emit('command_error', chunks);
@@ -183,8 +187,14 @@ BeanstalkCommand.prototype.responseHandler = function(data, callback) {
 			chunks.shift();
 
 			if(jobdata) {
+				// Accumulate last chunk, deep copy of this.rawBuffers (prototype),
+				// and concatenate all buffers
+				this.rawBuffers.push(data);
+				var rawBuffersCopy = this.rawBuffers.slice();
+				var reserveOutput = Buffer.concat(rawBuffersCopy);
+
 				chunks.pop();
-				chunks.push(jobdata);
+				chunks.push(this.extractDataReserveOutput(reserveOutput));
 				chunks = BeanstalkJob.create(chunks);
 			}
 		}
@@ -194,6 +204,22 @@ BeanstalkCommand.prototype.responseHandler = function(data, callback) {
 	}
 
 	return true;
+};
+
+/**
+ * Extract <data> from the full response for reserve command looking for
+ * the first "\r\n" aparition.
+ */
+BeanstalkCommand.prototype.extractDataReserveOutput = function(buff) {
+	var i;
+	var length = buff.length;
+
+	for(i = 0; i < length - 1; i++) {
+		if(buff[i] === 0x0d && buff[i+1] === 0x0a) {
+			return buff.slice(i + 2, length - 2);
+		}
+	}
+	return buff;
 };
 
 // ##Beanstalk client

--- a/lib/beanstalk_client.js
+++ b/lib/beanstalk_client.js
@@ -356,7 +356,7 @@ BeanstalkClient.prototype.put = function(data, priority, delay, ttr) {
 	}
 
 	return this.command({
-		command: 'put '+priority+' '+delay+' '+ttr+' '+Buffer.byteLength(data.toString(), 'utf8')+'\r\n'+data+'\r\n',
+		command: this._createPutCommand(data, priority, delay, ttr),
 		expected: 'INSERTED'
 	});
 };
@@ -568,6 +568,38 @@ BeanstalkClient.prototype.quit = function() {
 	return this.command({
 		command: 'quit\r\n'
 	});
+};
+
+// Private
+
+/**
+ * Creates the correct put command for the data provided. It allows to send strings or
+ * raw buffers to Beanstalk.
+ *
+ * @param {string|Buffer} data
+ * @param {number} priority
+ * @param {number} delay
+ * @param {number} ttr
+ * @returns {string|Buffer}
+ * @private
+ */
+BeanstalkClient.prototype._createPutCommand = function(data, priority, delay, ttr) {
+	var command;
+
+	if(typeof data === 'string') {
+		command = 'put ' + priority + ' ' + delay + ' ' + ttr + ' '
+				+ Buffer.byteLength(data.toString(), 'utf8') + '\r\n' + data + '\r\n';
+	} else {
+		var commandBegin = 'put ' + priority + ' ' + delay + ' ' + ttr + ' ' + data.length + '\r\n';
+		var commandEnd = '\r\n';
+
+		command = new Buffer(commandBegin.length + data.length + commandEnd.length);
+		command.write(commandBegin, 0, commandBegin.length, 'binary');
+		data.copy(command, commandBegin.length, 0, data.length);
+		command.write(commandEnd, commandBegin.length + data.length, commandEnd.length, 'binary');
+	}
+
+	return command;
 };
 
 // ##Exposed to node

--- a/package.json
+++ b/package.json
@@ -39,6 +39,10 @@
     {
       "name": "Joel Bradshaw",
       "github": "https://github.com/cincodenada"
+    },
+    {
+      "name": "Alejandro Santiago",
+      "github": "https://github.com/alemures"
     }
   ],
   "repository": {

--- a/tests/helper.js
+++ b/tests/helper.js
@@ -37,8 +37,8 @@ module.exports = {
 
 		mock_server.listen(port);
 	},
-	getClient : function () {
-		return bs.Client('127.0.0.1:' + port);
+	getClient : function (isRaw) {
+		return bs.Client('127.0.0.1:' + port, isRaw || false);
 	},
 	activateDebug : function() {
 		bs.Debug.activate();

--- a/tests/test_put_buffer.js
+++ b/tests/test_put_buffer.js
@@ -1,0 +1,44 @@
+console.log('testing put buffer');
+
+var assert = require('assert');
+var helper = require('./helper');
+var util = require('util');
+
+var data1 = new Buffer([1,2,3,4]);
+var data2 = new Buffer([1,2,3,4]);
+
+helper.bind(function(conn, data) {
+	if(String(data).indexOf('put') > -1) {
+		var dataBuff = extractDataReserveOutput(data);
+
+		assert(data2.equals(dataBuff), util.inspect(dataBuff) + " !== " + util.inspect(data2));
+
+		conn.write("INSERTED 1\r\n");
+	}
+	
+	if(String(data) == "use default\r\n") {
+		conn.write('USING default\r\n');
+		this.close();
+	}
+}, false);
+
+// Isn't necessary a raw client to use put with buffers
+var client = helper.getClient();
+client.use('default').onSuccess(function(data) {
+	client.put(data1, 100, 0).onSuccess(function(data) {
+		client.disconnect();
+	});
+});
+
+// Copied from BeanstalkCommand.prototype._extractDataReserveOutput
+function extractDataReserveOutput(buff) {
+	var i;
+	var length = buff.length;
+
+	for(i = 0; i < length - 1; i++) {
+		if(buff[i] === 0x0d && buff[i+1] === 0x0a) {
+			return buff.slice(i + 2, length - 2);
+		}
+	}
+	return buff;
+}

--- a/tests/test_reserve_buffer.js
+++ b/tests/test_reserve_buffer.js
@@ -1,0 +1,32 @@
+console.log('testing reserve buffer');
+
+var assert = require('assert');
+var helper = require('./helper');
+var util = require('util');
+
+var commandBegin = "RESERVED 1 4\r\n";
+var data1 = new Buffer([1,2,3,4]);
+var data2 = new Buffer(data1);
+var commandEnd = "\r\n";
+
+var command = new Buffer(commandBegin.length + data1.length + commandEnd.length);
+command.write(commandBegin, 0, commandBegin.length, 'binary');
+data1.copy(command, commandBegin.length, 0, data1.length);
+command.write(commandEnd, commandBegin.length + data1.length, commandEnd.length, 'binary');
+
+helper.bind(function(conn, data) {
+	if(String(data) == 'reserve\r\n') {
+		conn.write(command);
+	}
+}, true);
+
+var client = helper.getClient(true);
+client.reserve().onSuccess(function(data) {
+	var dataBuff = data.data;
+
+	assert(dataBuff instanceof Buffer, "the job data is not a buffer");
+	assert(data2.equals(dataBuff), util.inspect(dataBuff) + " !== " + util.inspect(data2));
+
+	console.log('test passed');
+	client.disconnect();
+});


### PR DESCRIPTION
The library is able to put and reserve raw Buffers. The put command is working with strings and Buffers getting the data type with "typeof" and building the correct beanstalk payload. In order to reserve raw Buffers, I have added a new parameter to the constructor BeanstalkCommand called "isRaw", depending on this new parameter, the reserve method will return strings or Buffers.